### PR TITLE
chore(deps): bump Embassy stack and related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,15 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,9 +46,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "az"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "bare-metal"
@@ -129,10 +120,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "defmt",
+ "num-traits",
+ "pure-rust-locales",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -142,6 +154,16 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
 ]
 
 [[package]]
@@ -173,7 +195,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -246,7 +268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -257,7 +279,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -265,15 +287,6 @@ name = "debug-helper"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
-
-[[package]]
-name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.0.1",
-]
 
 [[package]]
 name = "defmt"
@@ -295,7 +308,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -309,23 +322,23 @@ dependencies = [
 
 [[package]]
 name = "defmt-rtt"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+checksum = "93d5a25c99d89c40f5676bec8cefe0614f17f0f40e916f98e345dae941807f9e"
 dependencies = [
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
 ]
 
 [[package]]
 name = "defmt-test"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1e67ff0e1c6b1a9540a1a3e04454658faacdd188c91987c444d56e469d7dea"
+checksum = "24076cc7203c365e7febfcec15d6667a9ef780bd2c5fd3b2a197400df78f299b"
 dependencies = [
  "cortex-m-rt",
  "cortex-m-semihosting",
- "defmt 0.3.100",
+ "defmt",
  "defmt-test-macros",
 ]
 
@@ -337,7 +350,7 @@ checksum = "fe5520fd36862f281c026abeaab153ebbc001717c29a9b8e5ba9704d8f3a879d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -367,12 +380,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1611b7a7ab5d1fbed84c338df26d56fd9bded58006ebb029075112ed2c5e039"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
- "embassy-hal-internal",
+ "embassy-hal-internal 0.4.0",
  "embassy-sync",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
@@ -384,44 +397,61 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f102d5e04befe3ea74b6f41a0e26218740124636eb2f59e1cc215b5839b96df2"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "cortex-m",
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
  "document-features",
  "embassy-executor-macros",
+ "embassy-executor-timer-queue",
 ]
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
-name = "embassy-futures"
-version = "0.1.1"
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "embassy-hal-internal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568659fc53866d3d85c60fa33723fb751aa69e71507634fc2c19e7649432fb75"
 dependencies = [
  "cortex-m",
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
  "num-traits",
 ]
 
@@ -433,9 +463,9 @@ checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
 
 [[package]]
 name = "embassy-net-driver-channel"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a567ab50319d866ad5e6c583ed665ba9b07865389644d3d82e45bf1497c934"
+checksum = "a07d2eb9f05a6fc876500949856ea1be40773d866d8cb99384f72d0ae4568c16"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -444,20 +474,20 @@ dependencies = [
 
 [[package]]
 name = "embassy-rp"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c452bbeacf409444a953a834de4a5682b906d2af2703a4f1d68d741f992224"
+checksum = "5d98f472894c1ecffac5596c657af5305c57282d29e8746d7fec033951931bc8"
 dependencies = [
- "atomic-polyfill",
  "cfg-if",
+ "chrono",
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-hal-internal",
+ "embassy-hal-internal 0.5.0",
  "embassy-sync",
  "embassy-time",
  "embassy-time-driver",
@@ -467,8 +497,8 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
- "embedded-io-async",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.7.0",
  "embedded-storage",
  "embedded-storage-async",
  "fixed",
@@ -484,67 +514,69 @@ dependencies = [
 
 [[package]]
 name = "embassy-sync"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c372c90d3525a648684fa1c131decaf7d9ff181030db09c876fad6043443b9"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
+ "embedded-io-async 0.7.0",
  "futures-core",
  "futures-sink",
- "heapless",
+ "heapless 0.9.2",
 ]
 
 [[package]]
 name = "embassy-time"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt 0.3.100",
+ "defmt",
  "document-features",
  "embassy-time-driver",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "futures-util",
+ "futures-core",
 ]
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b742d6fec7afcfa77c91b476520627151da3735fca6373b287c4c94b69e171"
+checksum = "7fe6ecec32eac4f98c5427904006b0fc61f77d350e1572530f744ef14650f7a1"
 dependencies = [
- "embassy-executor",
- "heapless",
+ "embassy-executor-timer-queue",
+ "heapless 0.9.2",
 ]
 
 [[package]]
 name = "embassy-usb"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb69c7ca7fa90b9ae590e3dea985ef80df06d900a350f9cc9d3f3c8113fc4370"
+checksum = "a25746d8b152b72fbf2a217f489a083dbbe243f281f09184a1f2cfbe9bbb245f"
 dependencies = [
- "defmt 1.0.1",
+ "bitflags 2.9.2",
+ "defmt",
  "embassy-futures",
  "embassy-net-driver-channel",
  "embassy-sync",
+ "embassy-time",
  "embassy-usb-driver",
- "embedded-io-async",
- "heapless",
+ "embedded-io-async 0.7.0",
+ "heapless 0.9.2",
  "ssmarshal",
  "usbd-hid",
 ]
@@ -555,8 +587,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17119855ccc2d1f7470a39756b12068454ae27a3eabb037d940b5c03d9c77b7a"
 dependencies = [
- "defmt 1.0.1",
- "embedded-io-async",
+ "defmt",
+ "embedded-io-async 0.6.1",
 ]
 
 [[package]]
@@ -609,14 +641,13 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal-bus"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3980bf28e8577db59fe2bdb3df868a419469d2cecb363644eea2b6f7797669"
+checksum = "513e0b3a8fb7d3013a8ae17a834283f170deaf7d0eeab0a7c1a36ad4dd356d22"
 dependencies = [
  "critical-section",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "portable-atomic",
 ]
 
 [[package]]
@@ -636,12 +667,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
 name = "embedded-io-async"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.6.1",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -681,10 +727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "fixed"
-version = "1.29.0"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
 dependencies = [
  "az",
  "bytemuck",
@@ -726,21 +778,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
-name = "futures-task"
-version = "0.3.31"
+name = "generator"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -792,6 +841,16 @@ name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "stable_deref_trait",
@@ -864,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +955,28 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -925,6 +1012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +1047,7 @@ checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -962,9 +1058,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "panic-halt"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+checksum = "a513e167849a384b7f9b746e517604398518590a9142f4846a32e3c2a4de7b11"
 
 [[package]]
 name = "parking_lot"
@@ -1027,12 +1123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pio"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,7 +1167,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1114,7 +1204,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1133,7 +1223,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
  "defmt-rtt",
  "defmt-test",
  "embassy-executor",
@@ -1147,13 +1237,22 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-bus",
  "fixed",
- "heapless",
+ "heapless 0.9.2",
  "nb 1.1.0",
  "panic-halt",
  "portable-atomic",
  "st7735-lcd",
  "static_cell",
  "usbd-hid",
+]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
@@ -1268,6 +1367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1410,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1323,6 +1428,21 @@ dependencies = [
  "digest",
  "keccak",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -1383,9 +1503,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_cell"
-version = "1.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd3f559c6c41cde362aed95cd84765907e06057f087b17269b41750ec40a3e7"
+checksum = "0530892bb4fa575ee0da4b86f86c667132a94b74bb72160f58ee5a4afec74c23"
 dependencies = [
  "portable-atomic",
 ]
@@ -1407,17 +1527,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1465,7 +1574,77 @@ checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1498,36 +1677,34 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
 [[package]]
 name = "usbd-hid"
-version = "0.8.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f291ab53d428685cc780f08a2eb9d5d6ff58622db2b36e239a4f715f1e184c"
+checksum = "68beab087e4971a2fe76f631478b0e91d39593f58efd2775026ce6dc07a7bac6"
 dependencies = [
- "serde",
- "ssmarshal",
  "usb-device",
  "usbd-hid-macros",
 ]
 
 [[package]]
 name = "usbd-hid-descriptors"
-version = "0.8.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee54712c5d778d2fb2da43b1ce5a7b5060886ef7b09891baeb4bf36910a3ed"
+checksum = "b297f021719c4308d5d0c61b6c1e7c6b3ba383deba774b49aa5484f996bdb8f1"
 dependencies = [
  "bitfield 0.14.0",
 ]
 
 [[package]]
 name = "usbd-hid-macros"
-version = "0.8.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
+checksum = "011a3219e0933f5b3ad7dc90d9a66541a967d084c98c067deed1cd608e557ed7"
 dependencies = [
  "byteorder",
  "hashbrown 0.13.2",
@@ -1535,9 +1712,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn",
  "usbd-hid-descriptors",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcell"
@@ -1583,6 +1766,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1675,5 +1873,5 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ name = "productiondeck"
 path = "src/lib.rs"
 
 [dependencies]
-# Embassy framework for RP2040 - latest versions
-embassy-rp = { version = "0.7", features = ["defmt", "unstable-pac", "time-driver", "rp2040", "critical-section-impl"] }
-embassy-usb = { version = "0.5", features = ["defmt"] }
-embassy-time = { version = "0.4", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-executor = { version = "0.8", features = ["defmt", "arch-cortex-m", "executor-thread", "executor-interrupt"] }
+# Embassy framework for RP2040
+embassy-rp = { version = "0.10", features = ["defmt", "unstable-pac", "time-driver", "rp2040", "critical-section-impl"] }
+embassy-usb = { version = "0.6", features = ["defmt"] }
+embassy-time = { version = "0.5", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-executor = { version = "0.10", features = ["defmt", "platform-cortex-m", "executor-thread", "executor-interrupt"] }
 embassy-futures = "0.1"
-embassy-sync = "0.7"
+embassy-sync = "0.8"
 
 # Cortex-M runtime
 cortex-m = "0.7"
@@ -27,7 +27,7 @@ critical-section = "1.0"
 # Hardware abstraction
 embedded-hal = "1.0"
 embedded-hal-async = "1.0"
-embedded-hal-bus = { version = "0.2", features = ["async"] }
+embedded-hal-bus = { version = "0.3", features = ["async"] }
 portable-atomic = { version = "1.0", features = ["critical-section"] }
 
 # Display and graphics
@@ -35,20 +35,20 @@ st7735-lcd = "0.10"
 embedded-graphics = "0.8"
 
 # USB HID
-usbd-hid = "0.8"
+usbd-hid = "0.10"
 
 # Utilities
-heapless = { version = "0.8", default-features = false }
+heapless = { version = "0.9", default-features = false }
 nb = "1.1"
-panic-halt = "0.2"
+panic-halt = "1.0"
 defmt = "1.0.1"
-defmt-rtt = "1.0.0"
-fixed = "1.24"
-static_cell = "1.0"
+defmt-rtt = "1.1"
+fixed = "1.31"
+static_cell = "2.1"
 
 # Development dependencies
 [dev-dependencies]
-defmt-test = "0.3"
+defmt-test = "0.4"
 
 # Cargo build configuration
 [profile.release]

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -108,10 +108,10 @@ pub fn run_multicore(
             let executor1 = EXECUTOR1.init(Executor::new());
             executor1.run(|spawner| match core1_buf {
                 MulticoreCore1Buffer::B8192 => {
-                    unwrap!(spawner.spawn(multicore_core1_image_task_8192(device)));
+                    unwrap!(multicore_core1_image_task_8192(device).map(|t| spawner.spawn(t)));
                 }
                 MulticoreCore1Buffer::B16384 => {
-                    unwrap!(spawner.spawn(multicore_core1_image_task_16384(device)));
+                    unwrap!(multicore_core1_image_task_16384(device).map(|t| spawner.spawn(t)));
                 }
             });
         },
@@ -119,15 +119,16 @@ pub fn run_multicore(
 
     let executor0 = EXECUTOR0.init(Executor::new());
     executor0.run(|spawner| {
-        unwrap!(spawner.spawn(multicore_core0_supervisor_task(supervisor)));
+        unwrap!(multicore_core0_supervisor_task(supervisor).map(|t| spawner.spawn(t)));
         match layout {
             MulticoreCore0Layout::MiniOrModule6Direct => {
-                unwrap!(spawner.spawn(usb::usb_task_for_device(
+                unwrap!(usb::usb_task_for_device(
                     Driver::new(p.USB, crate::Irqs),
                     Output::new(p.PIN_20, Level::Low),
                     device,
-                )));
-                unwrap!(spawner.spawn(buttons::button_task_direct({
+                )
+                .map(|t| spawner.spawn(t)));
+                unwrap!(buttons::button_task_direct({
                     let mut inputs = heapless::Vec::new();
                     let _ = inputs.push(Input::new(p.PIN_4, Pull::Up));
                     let _ = inputs.push(Input::new(p.PIN_5, Pull::Up));
@@ -136,19 +137,22 @@ pub fn run_multicore(
                     let _ = inputs.push(Input::new(p.PIN_11, Pull::Up));
                     let _ = inputs.push(Input::new(p.PIN_12, Pull::Up));
                     inputs
-                })));
-                unwrap!(spawner.spawn(hardware::status_task(
+                })
+                .map(|t| spawner.spawn(t)));
+                unwrap!(hardware::status_task(
                     Output::new(p.PIN_25, Level::Low),
                     Output::new(p.PIN_21, Level::Low),
-                )));
+                )
+                .map(|t| spawner.spawn(t)));
             }
             MulticoreCore0Layout::Module15Matrix => {
-                unwrap!(spawner.spawn(usb::usb_task_for_device(
+                unwrap!(usb::usb_task_for_device(
                     Driver::new(p.USB, crate::Irqs),
                     Output::new(p.PIN_20, Level::Low),
                     device,
-                )));
-                unwrap!(spawner.spawn(buttons::button_task_matrix_5x3(
+                )
+                .map(|t| spawner.spawn(t)));
+                unwrap!(buttons::button_task_matrix_5x3(
                     Output::new(p.PIN_2, Level::High),
                     Output::new(p.PIN_3, Level::High),
                     Output::new(p.PIN_7, Level::High),
@@ -157,19 +161,22 @@ pub fn run_multicore(
                     Input::new(p.PIN_6, Pull::Up),
                     Input::new(p.PIN_10, Pull::Up),
                     Input::new(p.PIN_11, Pull::Up),
-                )));
-                unwrap!(spawner.spawn(hardware::status_task(
+                )
+                .map(|t| spawner.spawn(t)));
+                unwrap!(hardware::status_task(
                     Output::new(p.PIN_25, Level::Low),
                     Output::new(p.PIN_21, Level::Low),
-                )));
+                )
+                .map(|t| spawner.spawn(t)));
             }
             MulticoreCore0Layout::Module32Matrix => {
-                unwrap!(spawner.spawn(usb::usb_task_for_device(
+                unwrap!(usb::usb_task_for_device(
                     Driver::new(p.USB, crate::Irqs),
                     Output::new(p.PIN_25, Level::Low),
                     device,
-                )));
-                unwrap!(spawner.spawn(buttons::button_task_matrix_8x4(
+                )
+                .map(|t| spawner.spawn(t)));
+                unwrap!(buttons::button_task_matrix_8x4(
                     Output::new(p.PIN_2, Level::High),
                     Output::new(p.PIN_3, Level::High),
                     Output::new(p.PIN_7, Level::High),
@@ -182,11 +189,13 @@ pub fn run_multicore(
                     Input::new(p.PIN_12, Pull::Up),
                     Input::new(p.PIN_13, Pull::Up),
                     Input::new(p.PIN_16, Pull::Up),
-                )));
-                unwrap!(spawner.spawn(hardware::status_task(
+                )
+                .map(|t| spawner.spawn(t)));
+                unwrap!(hardware::status_task(
                     Output::new(p.PIN_20, Level::Low),
                     Output::new(p.PIN_21, Level::Low),
-                )));
+                )
+                .map(|t| spawner.spawn(t)));
             }
         }
     });

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -116,7 +116,7 @@ pub async fn init_hardware_tasks_core0(
         create_all_pins_for_device(p, hw_config.device);
 
     // Spawn USB task
-    spawner.spawn(usb_task_for_device(driver, usb_led, hw_config.device))?;
+    spawner.spawn(usb_task_for_device(driver, usb_led, hw_config.device)?);
 
     // For Mini devices, prefer Direct pin mode with 6 dedicated inputs
     if matches!(
@@ -132,7 +132,7 @@ pub async fn init_hardware_tasks_core0(
     spawn_button_task_with_pins(spawner, row_pins, col_pins, device)?;
 
     // Spawn status LED task
-    spawner.spawn(status_task(status_led, error_led))?;
+    spawner.spawn(status_task(status_led, error_led)?);
 
     Ok(())
 }
@@ -172,7 +172,7 @@ async fn init_hardware_tasks_with_config(
         create_all_pins_for_device(p, hw_config.device);
 
     // Spawn USB task
-    spawner.spawn(usb_task_for_device(driver, usb_led, hw_config.device))?;
+    spawner.spawn(usb_task_for_device(driver, usb_led, hw_config.device)?);
 
     // For Mini devices, prefer Direct pin mode with 6 dedicated inputs
     let device = hw_config.device;
@@ -192,7 +192,7 @@ async fn init_hardware_tasks_with_config(
     // spawn_display_task(spawner, p, &hw_config)?;
 
     // Spawn status LED task
-    spawner.spawn(status_task(status_led, error_led))?;
+    spawner.spawn(status_task(status_led, error_led)?);
 
     Ok(())
 }
@@ -321,7 +321,8 @@ fn spawn_button_task_with_pins(
                     let col2 = col_pins.pop().unwrap();
                     let col1 = col_pins.pop().unwrap();
                     let col0 = col_pins.pop().unwrap();
-                    spawner.spawn(button_task_matrix_3x2(row0, row1, col0, col1, col2))
+                    spawner.spawn(button_task_matrix_3x2(row0, row1, col0, col1, col2)?);
+                    Ok(())
                 }
                 (2, 4) => {
                     let row1 = row_pins.pop().unwrap();
@@ -330,7 +331,8 @@ fn spawn_button_task_with_pins(
                     let col2 = col_pins.pop().unwrap();
                     let col1 = col_pins.pop().unwrap();
                     let col0 = col_pins.pop().unwrap();
-                    spawner.spawn(button_task_matrix_4x2(row0, row1, col0, col1, col2, col3))
+                    spawner.spawn(button_task_matrix_4x2(row0, row1, col0, col1, col2, col3)?);
+                    Ok(())
                 }
                 (3, 5) => {
                     let row2 = row_pins.pop().unwrap();
@@ -343,7 +345,8 @@ fn spawn_button_task_with_pins(
                     let col0 = col_pins.pop().unwrap();
                     spawner.spawn(button_task_matrix_5x3(
                         row0, row1, row2, col0, col1, col2, col3, col4,
-                    ))
+                    )?);
+                    Ok(())
                 }
                 (4, 8) => {
                     let row3 = row_pins.pop().unwrap();
@@ -360,7 +363,8 @@ fn spawn_button_task_with_pins(
                     let col0 = col_pins.pop().unwrap();
                     spawner.spawn(button_task_matrix_8x4(
                         row0, row1, row2, row3, col0, col1, col2, col3, col4, col5, col6, col7,
-                    ))
+                    )?);
+                    Ok(())
                 }
                 (4, 9) => {
                     let row3 = row_pins.pop().unwrap();
@@ -379,7 +383,8 @@ fn spawn_button_task_with_pins(
                     spawner.spawn(button_task_matrix_9x4(
                         row0, row1, row2, row3, col0, col1, col2, col3, col4, col5, col6, col7,
                         col8,
-                    ))
+                    )?);
+                    Ok(())
                 }
                 _ => core::panic!("no matrix button task for {}×{}", layout.cols, layout.rows),
             }
@@ -400,7 +405,8 @@ fn spawn_button_task_with_pins(
                     let _ = inputs.pop();
                 }
             }
-            spawner.spawn(button_task_direct(inputs))
+            spawner.spawn(button_task_direct(inputs)?);
+            Ok(())
         }
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -15,7 +15,8 @@ use embassy_rp::peripherals;
 use embassy_rp::usb::Driver;
 use embassy_time::{Duration, Timer};
 use embassy_usb::class::hid::{
-    Config as HidConfig, HidReaderWriter, ReportId, RequestHandler, State,
+    Config as HidConfig, HidBootProtocol, HidReaderWriter, HidSubclass, ReportId, RequestHandler,
+    State,
 };
 use embassy_usb::control::OutResponse;
 use embassy_usb::{Builder, Config};
@@ -276,6 +277,8 @@ async fn usb_task_impl(
         request_handler: unsafe { REQUEST_HANDLER.as_mut().map(|h| h as _) },
         poll_ms: config::USB_POLL_RATE_MS as u8,
         max_packet_size: 64, // RP2040 USB hardware limitation
+        hid_subclass: HidSubclass::No,
+        hid_boot_protocol: HidBootProtocol::None,
     };
 
     info!(


### PR DESCRIPTION
## Summary
Updates direct dependencies to current stable lines, with Embassy components upgraded together for compatibility.

## Changes
- **Embassy**: `embassy-rp` 0.10, `embassy-usb` 0.6, `embassy-time` 0.5, `embassy-executor` 0.10, `embassy-sync` 0.8; executor feature `platform-cortex-m` (replaces `arch-cortex-m`).
- **Other**: `embedded-hal-bus` 0.3, `heapless` 0.9, `usbd-hid` 0.10, `static_cell` 2.1, `defmt-rtt` 1.1, `fixed` 1.31, `panic-halt` 1.0, `defmt-test` 0.4.
- **Code**: `HidConfig` gains `hid_subclass` / `hid_boot_protocol` (non-boot HID). Task spawn uses `Result<SpawnToken, _>` from embassy-executor 0.10.

## Verification
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`

Made with [Cursor](https://cursor.com)