### PR TITLE
feat: Flash unique ID based device serial

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@
 //! RP2040-based StreamDeck compatible device with multi-device support
 
 use crate::device::{Device, DeviceConfig, RUNTIME_DEVICE_TAG_UNINIT};
-use core::sync::atomic::{AtomicI32, AtomicPtr, AtomicU8, Ordering};
 use core::ptr;
+use core::sync::atomic::{AtomicI32, AtomicPtr, AtomicU8, Ordering};
 use defmt::warn;
 use embassy_rp::flash::{Blocking, Flash};
 use embassy_rp::peripherals::FLASH;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,13 @@
 //! RP2040-based StreamDeck compatible device with multi-device support
 
 use crate::device::{Device, DeviceConfig, RUNTIME_DEVICE_TAG_UNINIT};
-use core::sync::atomic::{AtomicI32, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicI32, AtomicPtr, AtomicU8, Ordering};
+use core::ptr;
+use defmt::warn;
+use embassy_rp::flash::{Blocking, Flash};
+use embassy_rp::peripherals::FLASH;
+use embassy_rp::Peri;
+use static_cell::StaticCell;
 
 // ===================================================================
 // Device Selection Configuration
@@ -54,8 +60,79 @@ pub fn button_input_mode() -> ButtonInputMode {
 // USB Configuration - Dynamic based on current device
 // ===================================================================
 
-/// Serial number (static for all devices)
-pub const USB_SERIAL: &str = "PRODUCTIONDK"; // 12 chars
+/// SPI flash size (matches `memory.x` 2048 KiB device).
+const FLASH_SIZE: usize = 2 * 1024 * 1024;
+
+const USB_SERIAL_FALLBACK: &[u8] = b"PRODUCTIONDK";
+
+struct UsbSerialStorage {
+    bytes: [u8; 17],
+    len: u8,
+}
+
+static USB_SERIAL_STORAGE: StaticCell<UsbSerialStorage> = StaticCell::new();
+static USB_SERIAL_PTR: AtomicPtr<UsbSerialStorage> = AtomicPtr::new(ptr::null_mut());
+
+fn hex_encode_lower_8(src: &[u8; 8], dst: &mut [u8]) {
+    debug_assert!(dst.len() >= 16);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for (i, &b) in src.iter().enumerate() {
+        dst[i * 2] = HEX[(b >> 4) as usize];
+        dst[i * 2 + 1] = HEX[(b & 0xf) as usize];
+    }
+}
+
+/// Read SPI flash unique ID once and build the USB / HID / module serial ASCII string.
+/// Call from [`crate::entry`] immediately after [`embassy_rp::init`], before other tasks consume [`FLASH`].
+pub fn init_usb_serial_from_flash(flash: Peri<'static, FLASH>) {
+    let mut flash = Flash::<FLASH, Blocking, FLASH_SIZE>::new_blocking(flash);
+    let mut uid = [0u8; 8];
+    let use_uid = match flash.blocking_unique_id(&mut uid) {
+        Ok(()) => {
+            let bad = uid.iter().all(|&b| b == 0xFF) || uid.iter().all(|&b| b == 0);
+            !bad
+        }
+        Err(e) => {
+            warn!("USB serial: flash unique_id failed: {:?}", e);
+            false
+        }
+    };
+
+    let mut bytes = [0u8; 17];
+    let len = if use_uid {
+        hex_encode_lower_8(&uid, &mut bytes[..16]);
+        16u8
+    } else {
+        warn!("USB serial: using PRODUCTIONDK fallback");
+        let n = USB_SERIAL_FALLBACK.len().min(bytes.len());
+        bytes[..n].copy_from_slice(&USB_SERIAL_FALLBACK[..n]);
+        n as u8
+    };
+
+    let slot = USB_SERIAL_STORAGE.init(UsbSerialStorage { bytes, len });
+    USB_SERIAL_PTR.store(slot, Ordering::Release);
+}
+
+/// Raw ASCII serial bytes (hex from flash UID, or [`USB_SERIAL_FALLBACK`]).
+///
+/// # Panics
+/// If [`init_usb_serial_from_flash`] has not run yet.
+pub fn usb_serial_bytes() -> &'static [u8] {
+    let p = USB_SERIAL_PTR.load(Ordering::Acquire);
+    assert!(!p.is_null(), "init_usb_serial_from_flash must run first");
+    unsafe {
+        let s = &*p;
+        core::slice::from_raw_parts(s.bytes.as_ptr(), s.len as usize)
+    }
+}
+
+/// USB string / logging: same buffer as [`usb_serial_bytes`].
+///
+/// # Panics
+/// If [`init_usb_serial_from_flash`] has not run yet.
+pub fn usb_serial_str() -> &'static str {
+    core::str::from_utf8(usb_serial_bytes()).expect("serial is ASCII")
+}
 
 /// USB version settings
 pub const USB_BCD_DEVICE: u16 = 0x0200; // Device version 2.0

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -97,6 +97,7 @@ pub fn run_multicore(
 ) -> ! {
     let p = embassy_rp::init(Default::default());
     config::init_runtime_device(device);
+    config::init_usb_serial_from_flash(p.FLASH);
 
     let supervisor = AppSupervisor::new_for_device(device);
     supervisor.print_startup_banner();

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -209,11 +209,35 @@ fn create_all_pins_for_device(
     Vec<Output<'static>, 4>,
     Vec<Input<'static>, 32>,
 ) {
+    let Peripherals {
+        FLASH,
+        USB,
+        PIN_2,
+        PIN_3,
+        PIN_4,
+        PIN_5,
+        PIN_6,
+        PIN_7,
+        PIN_9,
+        PIN_10,
+        PIN_11,
+        PIN_12,
+        PIN_13,
+        PIN_16,
+        PIN_20,
+        PIN_21,
+        PIN_22,
+        PIN_25,
+        ..
+    } = p;
+
+    crate::config::init_usb_serial_from_flash(FLASH);
+
     // Create USB driver and LEDs first
-    let driver = Driver::new(p.USB, crate::Irqs);
-    let usb_led = Output::new(p.PIN_20, Level::Low);
-    let status_led = Output::new(p.PIN_25, Level::Low);
-    let error_led = Output::new(p.PIN_21, Level::Low);
+    let driver = Driver::new(USB, crate::Irqs);
+    let usb_led = Output::new(PIN_20, Level::Low);
+    let status_led = Output::new(PIN_25, Level::Low);
+    let error_led = Output::new(PIN_21, Level::Low);
 
     // Create button pins
     let layout = device.button_layout();
@@ -229,72 +253,72 @@ fn create_all_pins_for_device(
         Device::Mini | Device::RevisedMini | Device::MiniDiscord
     ) {
         // Build six dedicated direct-input pins for Mini to avoid partial-move issues
-        let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-        let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-        let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
-        let _ = col_pins.push(Input::new(p.PIN_10, Pull::Up));
-        let _ = col_pins.push(Input::new(p.PIN_11, Pull::Up));
-        let _ = col_pins.push(Input::new(p.PIN_12, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_10, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_11, Pull::Up));
+        let _ = col_pins.push(Input::new(PIN_12, Pull::Up));
     } else {
         match (layout.rows, layout.cols) {
             (2, 3) => {
                 // Mini and Revised Mini (2x3 = 6 keys)
-                let _ = row_pins.push(Output::new(p.PIN_2, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_3, Level::High));
-                let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
+                let _ = row_pins.push(Output::new(PIN_2, Level::High));
+                let _ = row_pins.push(Output::new(PIN_3, Level::High));
+                let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
             }
             (2, 4) => {
                 // Stream Deck + / Neo (4x2 keys)
-                let _ = row_pins.push(Output::new(p.PIN_2, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_3, Level::High));
-                let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_10, Pull::Up));
+                let _ = row_pins.push(Output::new(PIN_2, Level::High));
+                let _ = row_pins.push(Output::new(PIN_3, Level::High));
+                let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_10, Pull::Up));
             }
             (3, 5) => {
                 // 15 Keys Module (5x3)
-                let _ = row_pins.push(Output::new(p.PIN_2, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_3, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_7, Level::High));
-                let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_10, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_11, Pull::Up));
+                let _ = row_pins.push(Output::new(PIN_2, Level::High));
+                let _ = row_pins.push(Output::new(PIN_3, Level::High));
+                let _ = row_pins.push(Output::new(PIN_7, Level::High));
+                let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_10, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_11, Pull::Up));
             }
             (4, 8) => {
                 // 32 Keys Module (8x4)
-                let _ = row_pins.push(Output::new(p.PIN_2, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_3, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_7, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_9, Level::High));
-                let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_10, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_11, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_12, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_13, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_16, Pull::Up));
+                let _ = row_pins.push(Output::new(PIN_2, Level::High));
+                let _ = row_pins.push(Output::new(PIN_3, Level::High));
+                let _ = row_pins.push(Output::new(PIN_7, Level::High));
+                let _ = row_pins.push(Output::new(PIN_9, Level::High));
+                let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_10, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_11, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_12, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_13, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_16, Pull::Up));
             }
             (4, 9) => {
                 // Stream Deck + XL (9x4)
-                let _ = row_pins.push(Output::new(p.PIN_2, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_3, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_7, Level::High));
-                let _ = row_pins.push(Output::new(p.PIN_9, Level::High));
-                let _ = col_pins.push(Input::new(p.PIN_4, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_5, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_6, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_10, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_11, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_12, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_13, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_16, Pull::Up));
-                let _ = col_pins.push(Input::new(p.PIN_22, Pull::Up));
+                let _ = row_pins.push(Output::new(PIN_2, Level::High));
+                let _ = row_pins.push(Output::new(PIN_3, Level::High));
+                let _ = row_pins.push(Output::new(PIN_7, Level::High));
+                let _ = row_pins.push(Output::new(PIN_9, Level::High));
+                let _ = col_pins.push(Input::new(PIN_4, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_5, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_6, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_10, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_11, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_12, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_13, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_16, Pull::Up));
+                let _ = col_pins.push(Input::new(PIN_22, Pull::Up));
             }
             _ => core::panic!("no pin mapping for matrix {}×{}", layout.cols, layout.rows),
         }

--- a/src/protocol/module_6.rs
+++ b/src/protocol/module_6.rs
@@ -104,7 +104,7 @@ impl Module6KeysHandler {
     }
 
     fn get_unit_serial_number(&self) -> &'static [u8] {
-        b"1234567890"
+        crate::config::usb_serial_bytes()
     }
 }
 

--- a/src/protocol/v1.rs
+++ b/src/protocol/v1.rs
@@ -279,7 +279,7 @@ impl ProtocolHandlerTrait for V1Handler {
                 buf,
                 report_id,
                 32,
-                crate::config::USB_SERIAL.as_bytes(),
+                crate::config::usb_serial_bytes(),
             ),
             0x04 => fill_feature_rid_ascii(buf, report_id, 17, 5, FW_VER),
             0x05 => fill_feature_v1_fw_string_report(buf, report_id, 32, FW_VER),

--- a/src/protocol/v2.rs
+++ b/src/protocol/v2.rs
@@ -440,7 +440,7 @@ impl ProtocolHandlerTrait for V2Handler {
                 }
                 feature_report_zero_prefix(buf, cap);
                 buf[0] = 0x06;
-                let serial = crate::config::USB_SERIAL.as_bytes();
+                let serial = crate::config::usb_serial_bytes();
                 let dl = core::cmp::min(serial.len(), 14) as u8;
                 buf[1] = dl;
                 let start = 2usize;

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -83,7 +83,7 @@ fn create_usb_config_for_device(device: Device) -> Config<'static> {
     let mut usb_config = Config::new(usb_config_data.vid, usb_config_data.pid);
     usb_config.manufacturer = Some(usb_config_data.manufacturer);
     usb_config.product = Some(usb_config_data.product_name);
-    usb_config.serial_number = Some(config::USB_SERIAL);
+    usb_config.serial_number = Some(config::usb_serial_str());
     usb_config.max_power = 100; // 200mA (matches real StreamDeck devices)
     usb_config.max_packet_size_0 = 64;
     usb_config.device_class = 0x00; // Interface-defined (HID class will be set in interface)


### PR DESCRIPTION
## Summary
Derives the Stream Deck–compatible serial string from the RP2040 external SPI flash unique ID (8-byte UID as 16-character lowercase hex). USB `iSerial`, v1/v2 HID serial feature reports, and module 6 unit serial all share this buffer.

If `blocking_unique_id` fails or returns an all-zero / all-0xFF UID, the firmware falls back to `PRODUCTIONDK` (unchanged behavior).

## Implementation notes
- Single-core builds: init runs inside `create_all_pins_for_device` after splitting `Peripherals` so `FLASH` can be consumed without partial-move issues.
- Multicore builds: init runs from `run_multicore` before Core 1 tasks.

Closes #5

Made with [Cursor](https://cursor.com)